### PR TITLE
migliorie di compatibilità hibernate

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,8 @@ spring:
     producer:
       topic: notifyOrderEvent
       group-id: cliente
+  jpa:
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl #"forza" ad adottare i nomi di @Table
+        implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl


### PR DESCRIPTION
Su Linux non comunicava col db perchè hibernate effettuava un cast del nome in snake_case, mentre il db usa notazione Pascal Case. Impostata la PhysicalNamingStrategy per seguire il tag @Table